### PR TITLE
Added SCALE_TYPE attribute defining how to scale the image

### DIFF
--- a/src/main/res/values/values.xml
+++ b/src/main/res/values/values.xml
@@ -4,4 +4,12 @@
         <attr name="maskDrawable" format="reference"/>
         <attr name="widthToHeightRatio" format="float"/>
     </declare-styleable>
+
+    <declare-styleable name="AtlasImageView">
+        <attr name="src" format="reference"/>
+        <attr name="scaleType" format="enum">
+            <enum name="SCALE_FIT" value="0"/>
+            <enum name="SCALE_FILL" value="1"/>
+        </attr>
+    </declare-styleable>
 </resources>


### PR DESCRIPTION
Image can be now scaled to fit (whitespace can be left) or fill (image can be cropped) the view.
Fit is used by default.